### PR TITLE
fix: remove unused Eq trait bounds to eliminate compiler warnings

### DIFF
--- a/src/adapton.mbt
+++ b/src/adapton.mbt
@@ -144,7 +144,7 @@ pub impl[A : Eq] Source for Thunk[A] with id(self) {
 }
 
 ///|
-pub impl[A : Eq] Source for Cell[A] with id(self) {
+pub impl[A] Source for Cell[A] with id(self) {
   self._id
 }
 
@@ -178,7 +178,7 @@ fn next_id() -> Int {
 }
 
 ///|
-pub fn[A : Eq] Thunk::new(thunk : () -> A) -> Thunk[A] {
+pub fn[A] Thunk::new(thunk : () -> A) -> Thunk[A] {
   {
     _id: next_id(),
     _value: None,
@@ -190,17 +190,17 @@ pub fn[A : Eq] Thunk::new(thunk : () -> A) -> Thunk[A] {
 }
 
 ///|
-pub fn[A : Eq] Cell::new(value : A) -> Cell[A] {
+pub fn[A] Cell::new(value : A) -> Cell[A] {
   { _id: next_id(), _value: value, _incoming_edges: [] }
 }
 
 ///| The same as `Thunk::new`
-pub fn[A : Eq] thunk(thunk : () -> A) -> Thunk[A] {
+pub fn[A] thunk(thunk : () -> A) -> Thunk[A] {
   Thunk::new(thunk)
 }
 
 ///| The same as `Cell::new`
-pub fn[A : Eq] cell(value : A) -> Cell[A] {
+pub fn[A] cell(value : A) -> Cell[A] {
   Cell::new(value)
 }
 
@@ -239,7 +239,7 @@ pub fn[A : Eq] Thunk::get(self : Thunk[A]) -> A {
 }
 
 ///|
-pub fn[A : Eq] Cell::get(self : Cell[A]) -> A {
+pub fn[A] Cell::get(self : Cell[A]) -> A {
   if not(target_stack.is_empty()) {
     let target = target_stack.last().unwrap()
     self._incoming_edges.push(target)
@@ -262,7 +262,7 @@ pub fn clear_memo() -> Unit {
 }
 
 ///|
-pub fn[A : Hash + Eq, B : Eq] memo(f : (A) -> B) -> (A) -> Thunk[B] {
+pub fn[A : Hash + Eq, B] memo(f : (A) -> B) -> (A) -> Thunk[B] {
   let h = {}
   memo_tables.push(fn() { h.clear() })
   fn(x) {
@@ -278,7 +278,7 @@ pub fn[A : Hash + Eq, B : Eq] memo(f : (A) -> B) -> (A) -> Thunk[B] {
 }
 
 ///|
-pub fn[A : Hash + Eq, B : Eq] memo_rec(
+pub fn[A : Hash + Eq, B] memo_rec(
   f : ((A) -> Thunk[B], A) -> B,
 ) -> (A) -> Thunk[B] {
   let h : Map[A, Thunk[B]] = {}
@@ -323,7 +323,7 @@ impl[A : Eq] Target for Thunk[A] with set_flag(self, flag) {
 }
 
 ///|
-pub impl[A : Eq] Source for Cell[A] with to_node(self) {
+pub impl[A] Source for Cell[A] with to_node(self) {
   None
 }
 
@@ -333,7 +333,7 @@ pub impl[A : Eq] Source for Thunk[A] with to_node(self) {
 }
 
 ///|
-pub impl[A : Eq] Source for Cell[A] with incoming_edges(self) {
+pub impl[A] Source for Cell[A] with incoming_edges(self) {
   self._incoming_edges
 }
 

--- a/src/adapton.mbt
+++ b/src/adapton.mbt
@@ -279,7 +279,7 @@ pub fn[A : Hash + Eq, B : Eq] memo(f : (A) -> B) -> (A) -> Thunk[B] {
 
 ///|
 pub fn[A : Hash + Eq, B : Eq] memo_rec(
-  f : ((A) -> Thunk[B], A) -> B
+  f : ((A) -> Thunk[B], A) -> B,
 ) -> (A) -> Thunk[B] {
   let h : Map[A, Thunk[B]] = {}
   memo_tables.push(fn() { h.clear() })

--- a/src/adapton.mbti
+++ b/src/adapton.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "illusory0x0/adapton"
 
 // Values
@@ -10,6 +11,8 @@ fn[A : Hash + Eq, B : Eq] memo((A) -> B) -> (A) -> Thunk[B]
 fn[A : Hash + Eq, B : Eq] memo_rec(((A) -> Thunk[B], A) -> B) -> (A) -> Thunk[B]
 
 fn[A : Eq] thunk(() -> A) -> Thunk[A]
+
+// Errors
 
 // Types and methods
 type Cell[A]

--- a/src/adapton.mbti
+++ b/src/adapton.mbti
@@ -2,31 +2,31 @@
 package "illusory0x0/adapton"
 
 // Values
-fn[A : Eq] cell(A) -> Cell[A]
+fn[A] cell(A) -> Cell[A]
 
 fn clear_memo() -> Unit
 
-fn[A : Hash + Eq, B : Eq] memo((A) -> B) -> (A) -> Thunk[B]
+fn[A : Hash + Eq, B] memo((A) -> B) -> (A) -> Thunk[B]
 
-fn[A : Hash + Eq, B : Eq] memo_rec(((A) -> Thunk[B], A) -> B) -> (A) -> Thunk[B]
+fn[A : Hash + Eq, B] memo_rec(((A) -> Thunk[B], A) -> B) -> (A) -> Thunk[B]
 
-fn[A : Eq] thunk(() -> A) -> Thunk[A]
+fn[A] thunk(() -> A) -> Thunk[A]
 
 // Errors
 
 // Types and methods
 type Cell[A]
-fn[A : Eq] Cell::get(Self[A]) -> A
+fn[A] Cell::get(Self[A]) -> A
 fn[A : Eq] Cell::modify(Self[A], (A) -> A) -> Unit
-fn[A : Eq] Cell::new(A) -> Self[A]
+fn[A] Cell::new(A) -> Self[A]
 fn[A : Eq] Cell::set(Self[A], A) -> Unit
-impl[A : Eq] Source for Cell[A]
+impl[A] Source for Cell[A]
 impl[A] Eq for Cell[A]
 impl[A] Hash for Cell[A]
 
 type Thunk[A]
 fn[A : Eq] Thunk::get(Self[A]) -> A
-fn[A : Eq] Thunk::new(() -> A) -> Self[A]
+fn[A] Thunk::new(() -> A) -> Self[A]
 impl[A : Eq] Source for Thunk[A]
 impl[A] Eq for Thunk[A]
 impl[A] Hash for Thunk[A]


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit removes unused `Eq` trait bounds from various type parameters
throughout the adapton library where the `Eq` constraint was not actually
being used in the method implementations.

Specific changes:
- Removed `Eq` bound from `Source` impl for `Cell[A]` in `id` and `incoming_edges` methods
- Removed `Eq` bound from `Thunk::new` and `Cell::new` constructors  
- Removed `Eq` bound from `thunk` and `cell` helper functions
- Removed `Eq` bound from `Cell::get` method
- Removed unused `B : Eq` bound from `memo` and `memo_rec` functions
- Removed `Eq` bound from `Source` impl for `Cell[A]` in `to_node` method

All tests continue to pass and the functionality remains unchanged.
This resolves all compiler warnings about unused trait bounds (warning[0053]).