### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/src/adapton.mbt
+++ b/src/adapton.mbt
@@ -132,7 +132,7 @@ pub impl[A] Hash for Cell[A] with hash_combine(self, hasher) {
 }
 
 ///|
-let node_counter : Ref[Int] = Ref::new(0)
+let node_counter : Ref[Int] = Ref(0)
 
 ///|
 fn next_id() -> Int {


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.
